### PR TITLE
Add reflection to materials and shaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ build
 .cache
 .clangd
 
-# Rust
-/naga-native/target
-
 # macOS
 .DS_Store
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 # Build for the web:
-# - Run cmake with `emcmake cmake .. -DWEB=1`
+# - Run cmake with `emcmake cmake -B build`
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 0)
@@ -21,6 +21,7 @@ list(APPEND SOURCES
     src/Render/Driver.cpp
     src/Render/Graph.cpp
     src/Render/Shader.cpp
+    src/Render/WGSLParser.cpp
     src/Scene/Entity.cpp
     src/Scene/Scene.cpp
     src/Camera.cpp
@@ -62,7 +63,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
-if(WEB)
+if(TARGET_IS_WEB)
     list(APPEND SOURCES
         src/Render/DriverWebGPU.cpp
         src/Emscripten.cpp
@@ -115,7 +116,7 @@ endif()
 if(TARGET_IS_WEB)
     configure_file(${CMAKE_SOURCE_DIR}/web/index.html ${CMAKE_BINARY_DIR}/index.html COPYONLY)
 
-    set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS "-sUSE_WEBGPU=1 -SUSE_SDL=2 -SsASYNCIFY=1 -sALLOW_MEMORY_GROWTH=1 --preload-file ../assets --bind") # --emrun
+    set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS "-sUSE_WEBGPU=1 -sASYNCIFY=1 -sALLOW_MEMORY_GROWTH=1 --preload-file ../assets --bind")
 
     # Make clangd recognize emscripten paths
     execute_process(COMMAND ${CMAKE_C_COMPILER} --cflags OUTPUT_VARIABLE CLANGD_FLAGS_TO_ADD)
@@ -153,11 +154,12 @@ if(TARGET_IS_LINUX OR TARGET_IS_APPLE OR TARGET_IS_MSVC)
     target_link_libraries(${TARGET_NAME} PRIVATE Vulkan::Headers)
 endif()
 
+# tint (Dawn's shader compiler)
 if(NOT TARGET_IS_WEB)
-    # Compile against `tint` only on desktop, on web we give WGSL shaders directly to WebGPU.
-
     set(DAWN_BUILD_SAMPLES OFF)
     set(DAWN_BUILD_TESTS OFF)
+
+    set(DAWN_USE_GLFW OFF)
 
     set(DAWN_ENABLE_D3D11 OFF)
     set(DAWN_ENABLE_D3D12 OFF)
@@ -167,16 +169,17 @@ if(NOT TARGET_IS_WEB)
     set(DAWN_ENABLE_OPENGLES OFF)
     set(DAWN_ENABLE_VULKAN OFF)
 
-    set(DAWN_USE_GLFW OFF)
-
     set(TINT_BUILD_TESTS OFF)
 
     set(TINT_BUILD_SPV_READER OFF)
     set(TINT_BUILD_WGSL_READER ON)
+
     set(TINT_BUILD_GLSL_WRITER OFF)
     set(TINT_BUILD_HLSL_WRITER OFF)
     set(TINT_BUILD_MSL_WRITER OFF)
     set(TINT_BUILD_SPV_WRITER ON)
+
+    set(TINT_BUILD_GLSL_VALIDATOR OFF)
 
     # This disable automatic validation and allow us to perform our own and set capabilities.
     set(TINT_ENABLE_IR_VALIDATION OFF)
@@ -188,6 +191,10 @@ if(NOT TARGET_IS_WEB)
         GIT_TAG e430bb9b0833137c4365fee39dfa930657b408fc
     )
     FetchContent_MakeAvailable(abseil)
+
+    # set(DAWN_THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+    # set(DAWN_EMDAWNWEBGPU_DIR ${CMAKE_BINARY_DIR}/_deps/dawn-src/third_party/emdawnwebgpu)
+    set(DAWN_ABSEIL_DIR ${abseil_SOURCE_DIR})
 
     # SPIRV-Headers
     FetchContent_Declare(
@@ -213,8 +220,6 @@ if(NOT TARGET_IS_WEB)
     )
     FetchContent_MakeAvailable(glslang)
 
-    set(DAWN_THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-    set(DAWN_ABSEIL_DIR ${abseil_SOURCE_DIR})
     set(DAWN_SPIRV_TOOLS_DIR ${spirvtools_SOURCE_DIR})
     set(DAWN_SPIRV_HEADERS_DIR ${spirvheaders_SOURCE_DIR})
     set(DAWN_GLSLANG_DIR ${glslang_SOURCE_DIR})
@@ -222,7 +227,9 @@ if(NOT TARGET_IS_WEB)
     FetchContent_Declare(
         dawn
         GIT_REPOSITORY https://dawn.googlesource.com/dawn
-        GIT_TAG 40dca384e6e6ad6afe3ed859017733455ee0b3d7
+        GIT_TAG 4d33621217632e25d8e88e2f0dd2544596d129ac
+        # This line will prevent cmake from fetching submodules, instead we fetch only the required dependencies
+        # with FetchContent.
         GIT_SUBMODULES ""
     )
     FetchContent_MakeAvailable(dawn)
@@ -270,7 +277,7 @@ target_compile_definitions(${TARGET_NAME} PRIVATE IMGUI_IMPL_VULKAN_NO_PROTOTYPE
 if(TARGET_IS_LINUX OR TARGET_IS_APPLE OR TARGET_IS_MSVC)
     target_sources(${TARGET_NAME} PRIVATE ${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp)
 elseif(TARGET_IS_WEB)
-    target_sources(${TARGET_NAME} PRIVATE ${imgui_SOURCE_DIR}/backends/imgui_impl_wgpu.cpp)
+    # target_sources(${TARGET_NAME} PRIVATE ${imgui_SOURCE_DIR}/backends/imgui_impl_wgpu.cpp)
 endif()
 
 # glm
@@ -330,13 +337,6 @@ if(TARGET_IS_LINUX OR TARGET_IS_APPLE)
         WORKING_DIRECTORY ${libbacktrace_BINARY_DIR}
     )
 
-    # Install
-    # execute_process(
-    #     OUTPUT_QUIET
-    #     COMMAND make install
-    #     WORKING_DIRECTORY ${libbacktrace_BINARY_DIR}
-    # )
-
     target_link_directories(${TARGET_NAME} PRIVATE ${libbacktrace_BINARY_DIR}/.libs)
     target_link_libraries(${TARGET_NAME} PRIVATE backtrace)
     target_include_directories(${TARGET_NAME} PRIVATE ${libbacktrace_SOURCE_DIR})
@@ -372,6 +372,6 @@ if (DOXYGEN_FOUND AND BUILD_DOC)
         VERBATIM )
 endif()
 
-foreach(RESOURCE IN LISTS RESOURCE_COPY)
-    configure_file(${CMAKE_SOURCE_DIR}/${RESOURCE} ${CMAKE_BINARY_DIR}/${RESOURCE} COPYONLY)
-endforeach()
+# foreach(RESOURCE IN LISTS RESOURCES_COPY)
+#     configure_file(${CMAKE_SOURCE_DIR}/${RESOURCE} ${CMAKE_BINARY_DIR}/${RESOURCE} COPYONLY)
+# endforeach()

--- a/src/Core/Error.hpp
+++ b/src/Core/Error.hpp
@@ -85,6 +85,9 @@ struct std::formatter<ErrorKind> : std::formatter<std::string>
         case ErrorKind::NoSuitableDevice:
             msg = "No suitable device";
             break;
+        case ErrorKind::ShaderCompilationFailed:
+            msg = "Shader compilation failed";
+            break;
         }
 
         std::format_to(ctx.out(), "{}", msg);
@@ -253,6 +256,8 @@ public:
     {
 #ifdef __has_vulkan
         std::println(fp, "Error: {} ({:x}) (from {})\n", (uint32_t)m_kind, (uint32_t)m_kind, string_vk_result((VkResult)m_vk_result));
+#else
+        std::println(fp, "Error: {}", (uint32_t)m_kind);
 #endif
 
         m_stacktrace.print(fp);

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -1,4 +1,5 @@
 #include "Font.hpp"
+
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
@@ -157,12 +158,12 @@ Expected<void> Font::init_library()
 
     Ref<Shader> shader = shader_result.value();
 
-    auto material_layout_result = RenderingDriver::get()->create_material_layout(shader,
-                                                                                 {
-                                                                                     MaterialParam::image(ShaderKind::Fragment, "bitmap", {.min_filter = Filter::Nearest, .mag_filter = Filter::Nearest}),
-                                                                                     MaterialParam::uniform_buffer(ShaderKind::Vertex, "uniform"),
-                                                                                 },
-                                                                                 {.transparency = true}, instance_layout);
+#ifdef __platform_web
+    shader->set_binding("bitmap", Binding{.kind = BindingKind::Texture, .shader_stage = ShaderStageKind::Fragment, .group = 0, .binding = 0, .dimension = TextureDimension::D2D});
+    shader->set_binding("data", Binding{.kind = BindingKind::UniformBuffer, .shader_stage = ShaderStageKind::Vertex, .group = 0, .binding = 2});
+#endif
+
+    auto material_layout_result = RenderingDriver::get()->create_material_layout(shader, {.transparency = true}, instance_layout);
     YEET(material_layout_result);
 
     g_material_layout = material_layout_result.value();
@@ -191,7 +192,7 @@ Text::Text(size_t capacity, Ref<Font> font)
     m_material = material_result.value();
 
     m_material->set_param("bitmap", font->get_bitmap());
-    m_material->set_param("uniform", m_uniform_buffer);
+    m_material->set_param("data", m_uniform_buffer);
 }
 
 void Text::set(const std::string& text)

--- a/src/Render/DriverVulkan.hpp
+++ b/src/Render/DriverVulkan.hpp
@@ -93,7 +93,7 @@ public:
     virtual Expected<Ref<Mesh>> create_mesh(IndexType index_type, Span<uint8_t> indices, Span<glm::vec3> vertices, Span<glm::vec2> uvs, Span<glm::vec3> normals) override;
 
     [[nodiscard]]
-    virtual Expected<Ref<MaterialLayout>> create_material_layout(Ref<Shader> shader, Span<MaterialParam> params = {}, MaterialFlags flags = {}, std::optional<InstanceLayout> instance_layout = std::nullopt, CullMode cull_mode = CullMode::Back, PolygonMode polygon_mode = PolygonMode::Fill) override;
+    virtual Expected<Ref<MaterialLayout>> create_material_layout(Ref<Shader> shader, MaterialFlags flags = {}, std::optional<InstanceLayout> instance_layout = std::nullopt, CullMode cull_mode = CullMode::Back, PolygonMode polygon_mode = PolygonMode::Fill) override;
 
     [[nodiscard]]
     virtual Expected<Ref<Material>> create_material(MaterialLayout *layout) override;
@@ -265,7 +265,7 @@ class DescriptorPool
 {
 public:
     [[nodiscard]]
-    static Expected<DescriptorPool> create(vk::DescriptorSetLayout layout, Span<MaterialParam> params);
+    static Expected<DescriptorPool> create(vk::DescriptorSetLayout layout, Ref<Shader> shader);
 
     [[nodiscard]]
     Expected<vk::DescriptorSet> allocate();
@@ -293,13 +293,10 @@ class MaterialLayoutVulkan : public MaterialLayout
     CLASS(MaterialLayoutVulkan, MaterialLayout);
 
 public:
-    MaterialLayoutVulkan(vk::DescriptorSetLayout m_descriptor_set_layout, DescriptorPool descriptor_pool, Ref<Shader> shader, std::optional<InstanceLayout> instance_layout, std::vector<MaterialParam> params, vk::PolygonMode polygon_mode, vk::CullModeFlags cull_mode, MaterialFlags flags, vk::PipelineLayout pipeline_layout)
-        : m_descriptor_pool(descriptor_pool), m_descriptor_set_layout(m_descriptor_set_layout), m_shader(shader), m_instance_layout(instance_layout), m_params(params), m_polygon_mode(polygon_mode), m_cull_mode(cull_mode), m_flags(flags), m_pipeline_layout(pipeline_layout)
+    MaterialLayoutVulkan(vk::DescriptorSetLayout m_descriptor_set_layout, DescriptorPool descriptor_pool, Ref<Shader> shader, std::optional<InstanceLayout> instance_layout, vk::PolygonMode polygon_mode, vk::CullModeFlags cull_mode, MaterialFlags flags, vk::PipelineLayout pipeline_layout)
+        : m_descriptor_pool(descriptor_pool), m_descriptor_set_layout(m_descriptor_set_layout), m_shader(shader), m_instance_layout(instance_layout), m_polygon_mode(polygon_mode), m_cull_mode(cull_mode), m_flags(flags), m_pipeline_layout(pipeline_layout)
     {
     }
-
-    std::optional<uint32_t> get_param_binding(const std::string& name);
-    std::optional<MaterialParam> get_param(const std::string& name);
 
     // private:
     DescriptorPool m_descriptor_pool;
@@ -307,7 +304,6 @@ public:
 
     Ref<Shader> m_shader;
     std::optional<InstanceLayout> m_instance_layout;
-    std::vector<MaterialParam> m_params;
     vk::PolygonMode m_polygon_mode;
     vk::CullModeFlags m_cull_mode;
     MaterialFlags m_flags;

--- a/src/Render/DriverWebGPU.hpp
+++ b/src/Render/DriverWebGPU.hpp
@@ -3,12 +3,13 @@
 #include "Core/Class.hpp"
 #include "Render/Driver.hpp"
 
+#include <webgpu/webgpu.h>
+#include <webgpu/webgpu_cpp.h>
+
 #ifdef __platform_web
 #include <emscripten.h>
 #include <emscripten/html5_webgpu.h>
 #endif
-
-#include <webgpu/webgpu_cpp.h>
 
 #include <map>
 
@@ -83,7 +84,7 @@ public:
     virtual Expected<Ref<Mesh>> create_mesh(IndexType index_type, Span<uint8_t> indices, Span<glm::vec3> vertices, Span<glm::vec2> uvs, Span<glm::vec3> normals) override;
 
     [[nodiscard]]
-    virtual Expected<Ref<MaterialLayout>> create_material_layout(Ref<Shader> shader, Span<MaterialParam> params = {}, MaterialFlags flags = {}, std::optional<InstanceLayout> instance_layout = std::nullopt, CullMode cull_mode = CullMode::Back, PolygonMode polygon_mode = PolygonMode::Fill) override;
+    virtual Expected<Ref<MaterialLayout>> create_material_layout(Ref<Shader> shader, MaterialFlags flags = {}, std::optional<InstanceLayout> instance_layout = std::nullopt, CullMode cull_mode = CullMode::Back, PolygonMode polygon_mode = PolygonMode::Fill) override;
 
     [[nodiscard]]
     virtual Expected<Ref<Material>> create_material(MaterialLayout *layout) override;
@@ -195,17 +196,14 @@ class MaterialLayoutWebGPU : public MaterialLayout
     CLASS(MaterialLayoutWebGPU, MaterialLayout);
 
 public:
-    MaterialLayoutWebGPU(wgpu::BindGroupLayout layout, Ref<Shader> shader, std::optional<InstanceLayout> instance_layout, std::vector<MaterialParam> params, wgpu::CullMode cull_mode, MaterialFlags flags, wgpu::PipelineLayout pipeline_layout)
-        : layout(layout), shader(shader), instance_layout(instance_layout), params(params), cull_mode(cull_mode), flags(flags), pipeline_layout(pipeline_layout)
+    MaterialLayoutWebGPU(wgpu::BindGroupLayout layout, Ref<Shader> shader, std::optional<InstanceLayout> instance_layout, wgpu::CullMode cull_mode, MaterialFlags flags, wgpu::PipelineLayout pipeline_layout)
+        : layout(layout), shader(shader), instance_layout(instance_layout), cull_mode(cull_mode), flags(flags), pipeline_layout(pipeline_layout)
     {
     }
-
-    std::optional<MaterialParam> get_param(const std::string& name);
 
     wgpu::BindGroupLayout layout;
     Ref<Shader> shader;
     std::optional<InstanceLayout> instance_layout;
-    std::vector<MaterialParam> params;
     wgpu::CullMode cull_mode;
     MaterialFlags flags;
     wgpu::PipelineLayout pipeline_layout;
@@ -224,15 +222,15 @@ public:
 
     union ParamCache
     {
-        MaterialParamKind kind;
+        BindingKind kind;
         struct
         {
-            MaterialParamKind kind;
+            BindingKind kind;
             TextureWebGPU *texture;
         } texture;
         struct
         {
-            MaterialParamKind kind;
+            BindingKind kind;
             BufferWebGPU *buffer;
         } buffer;
     };

--- a/src/Render/Types.hpp
+++ b/src/Render/Types.hpp
@@ -1,0 +1,217 @@
+#pragma once
+
+enum class VSync : uint8_t
+{
+    /**
+     * @brief Disable vertical synchronization.
+     */
+    Off,
+
+    /**
+     * @brief Enable vertical synchronization.
+     */
+    On,
+};
+
+enum class BufferVisibility : uint8_t
+{
+    /**
+     * @brief Indicate a buffer is only visible from GPU.
+     */
+    GPUOnly,
+
+    /**
+     * @brief Indicate a buffer visible from GPU and CPU.
+     */
+    GPUAndCPU,
+};
+
+struct BufferUsage
+{
+    /**
+     * @brief Used as source in copy operation.
+     */
+    bool copy_src : 1 = false;
+
+    /**
+     * @brief Used as destination in copy operation.
+     */
+    bool copy_dst : 1 = false;
+
+    /**
+     * @brief Used as an uniform buffer.
+     */
+    bool uniform : 1 = false;
+
+    /**
+     * @brief Used as an index buffer.
+     */
+    bool index : 1 = false;
+
+    /**
+     * @brief Used as an vertex or instance buffer.
+     */
+    bool vertex : 1 = false;
+};
+
+enum class TextureFormat : uint8_t
+{
+    R8Unorm,
+    RGBA8Unorm,
+
+    RGBA8Srgb,
+    BGRA8Srgb,
+
+    R32Sfloat,
+    RG32Sfloat,
+    RGB32Sfloat,
+    RGBA32Sfloat,
+
+    /**
+     * @brief Depth 32-bits per pixel.
+     */
+    D32,
+};
+
+size_t size_of(const TextureFormat& format);
+
+enum class TextureDimension : uint8_t
+{
+    D1D,
+    D2D,
+    D2DArray,
+    D3D,
+    Cube,
+    CubeArray,
+};
+
+struct TextureUsage
+{
+    /**
+     * @brief Used as source in copy operation.
+     */
+    bool copy_src : 1 = false;
+
+    /**
+     * @brief Used as destination in copy operation.
+     */
+    bool copy_dst : 1 = false;
+
+    bool sampled : 1 = false;
+
+    bool color_attachment : 1 = false;
+    bool depth_attachment : 1 = false;
+};
+
+// TODO: This probably should not be exposed.
+enum class TextureLayout : uint8_t
+{
+    Undefined,
+    DepthStencilAttachment,
+    CopyDst,
+    ShaderReadOnly,
+    DepthStencilReadOnly,
+};
+
+enum class IndexType : uint8_t
+{
+    Uint16,
+    Uint32,
+};
+
+size_t size_of(const IndexType& format);
+
+enum class PolygonMode : uint8_t
+{
+    Fill,
+    Line,
+    Point,
+};
+
+enum class CullMode : uint8_t
+{
+    None,
+    Front,
+    Back,
+};
+
+enum class ShaderType : uint8_t
+{
+    Float,
+    Vec2,
+    Vec3,
+    Vec4,
+
+    Uint,
+};
+
+enum class Filter : uint8_t
+{
+    Linear,
+    Nearest,
+};
+
+enum class AddressMode : uint8_t
+{
+    Repeat,
+    ClampToEdge,
+};
+
+struct Sampler
+{
+    Filter min_filter = Filter::Linear;
+    Filter mag_filter = Filter::Linear;
+
+    struct
+    {
+        AddressMode u = AddressMode::Repeat;
+        AddressMode v = AddressMode::Repeat;
+        AddressMode w = AddressMode::Repeat;
+    } address_mode = {};
+
+    bool operator<(const Sampler& o) const
+    {
+        if ((uint32_t)min_filter >= (uint32_t)o.min_filter)
+            return false;
+        if ((uint32_t)mag_filter >= (uint32_t)o.mag_filter)
+            return false;
+
+        if ((uint32_t)address_mode.u >= (uint32_t)o.address_mode.u)
+            return false;
+        if ((uint32_t)address_mode.v >= (uint32_t)o.address_mode.v)
+            return false;
+        if ((uint32_t)address_mode.w >= (uint32_t)o.address_mode.w)
+            return false;
+
+        return true;
+    }
+};
+
+enum class ShaderStageKind : uint8_t
+{
+    Vertex,
+    Fragment,
+    Compute,
+};
+
+enum class BindingKind : uint8_t
+{
+    Texture,
+    UniformBuffer,
+};
+
+struct Binding
+{
+    BindingKind kind;
+    ShaderStageKind shader_stage = ShaderStageKind::Vertex;
+    uint32_t group;
+    uint32_t binding;
+
+    union
+    {
+        /**
+         * Available only when binding is a `BindingKind::Texture`.
+         */
+        TextureDimension dimension = {};
+    };
+};

--- a/src/Render/WGSLParser.cpp
+++ b/src/Render/WGSLParser.cpp
@@ -1,0 +1,94 @@
+#include "Render/WGSLParser.hpp"
+
+enum class TokenKind : uint8_t
+{
+    Identifier,
+
+    Struct, // `struct`
+    Var,    // `var` with optional address space
+    Fn,     // `fn`
+
+    Attribute,
+
+    Colon,       // `:`
+    Semi,        // `;`
+    Assign,      // `=`
+    BracesLeft,  // `{`
+    BracesRight, // `}`
+    ParentLeft,  // `(`
+    ParentRight, // `)`
+};
+
+union Token
+{
+    TokenKind kind;
+
+    // @<name>(<value>) or @<name>
+    struct
+    {
+        TokenKind kind;
+        std::string name;
+        std::optional<std::string> value;
+    } attrib;
+    // var< <address_space> > or var
+    struct
+    {
+        TokenKind kind;
+        std::string address_space;
+    } var;
+
+    ~Token()
+    {
+    }
+};
+
+struct WGSLParser
+{
+    std::vector<Token> tokenize(const std::string& source)
+    {
+        std::vector<Token> tokens;
+        size_t index = 0;
+
+        WGSLAttribs attribs;
+
+        while (index < source.size())
+        {
+            // Skip whitespaces
+            while (std::isspace(source[index]))
+                index++;
+
+            char ch = source[index];
+
+            if (ch == '@')
+            {
+                index++;
+
+                std::string name;
+                std::string value;
+
+                while (index < source.size() && !std::isspace(source[index]) && source[index] != '(')
+                    name += source[index++];
+
+                while (index < source.size() && !std::isspace(source[index]) && source[index] != '(')
+                    name += source[index++];
+            }
+
+            index++;
+        }
+
+        return tokens;
+    }
+
+    WGSLModule parse(const std::string& source)
+    {
+        std::vector<Token> tokens = tokenize(source);
+        WGSLModule module;
+
+        return module;
+    }
+};
+
+WGSLModule WGSLModule::parse(const std::string& source)
+{
+    return WGSLParser{}.parse(source);
+}

--- a/src/Render/WGSLParser.hpp
+++ b/src/Render/WGSLParser.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Render/Types.hpp"
+
+struct WGSLAttribs
+{
+    std::optional<uint32_t> group;
+    std::optional<uint32_t> binding;
+};
+
+struct WGSLVar
+{
+    WGSLAttribs attribs;
+};
+
+struct WGSLModule
+{
+    static WGSLModule parse(const std::string& source);
+
+    std::vector<WGSLVar> vars;
+};


### PR DESCRIPTION
This remove the requirements of providing bindings when creating a material, it will use `tint` to retrieve all binding and their location. Except on web when bindings must be specified for now.